### PR TITLE
Accept credentials as impl Read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- Accept FCM credentials as impl Read (#9)
 - Handle ```duration_since``` error differently in the token_manager. (#1)
 
 

--- a/examples/axum_example.rs
+++ b/examples/axum_example.rs
@@ -1,6 +1,7 @@
 use axum::{extract::Extension, routing::post, Router};
 use oauth_fcm::{create_shared_token_manager, send_fcm_message, SharedTokenManager};
 use serde::Serialize;
+use std::fs::File;
 
 #[derive(Serialize)]
 struct MyData {
@@ -28,8 +29,9 @@ async fn send_notification(
 
 #[tokio::main]
 async fn main() {
-    let shared_token_manager = create_shared_token_manager("path/to/google/credentials.json")
-        .expect("Could not find credentials.json");
+    let shared_token_manager =
+        create_shared_token_manager(File::open("path/to/google/credentials.json").unwrap())
+            .expect("Could not find credentials.json");
 
     let app = Router::new()
         .route("/send", post(send_notification))

--- a/examples/rocket_example.rs
+++ b/examples/rocket_example.rs
@@ -1,5 +1,6 @@
 use rocket::{post, State};
 use serde::Serialize;
+use std::fs::File;
 
 use oauth_fcm::{create_shared_token_manager, send_fcm_message, SharedTokenManager};
 
@@ -35,7 +36,8 @@ async fn send_notification(token_manager: &State<SharedTokenManager>) -> Result<
 #[rocket::main]
 async fn main() {
     let shared_token_manager =
-        create_shared_token_manager("path/to/google/credentials.json").unwrap();
+        create_shared_token_manager(File::open("path/to/google/credentials.json").unwrap())
+            .unwrap();
 
     rocket::build()
         .manage(shared_token_manager)

--- a/src/fcm.rs
+++ b/src/fcm.rs
@@ -31,6 +31,8 @@ pub struct FcmNotification {
 /// # Example
 ///
 /// ```rust no_run
+/// use std::fs::File;
+///
 /// use oauth_fcm::{create_shared_token_manager, send_fcm_message, SharedTokenManager};
 ///
 /// # tokio_test::block_on(async {
@@ -42,7 +44,7 @@ pub struct FcmNotification {
 ///    title: "Test Title".to_string(),
 ///   body: "Test Body".to_string(),
 /// };
-/// let token_manager = create_shared_token_manager("path_to_google_credentials.json").expect("Failed to create SharedTokenManager");
+/// let token_manager = create_shared_token_manager(File::open("path_to_google_credentials.json").expect("Failed to open file")).expect("Failed to create SharedTokenManager");
 /// let project_id = "project_id";
 /// send_fcm_message(device_token, Some(notification), Some(data), &token_manager, project_id)
 ///     .await

--- a/tests/fcm_request_error.rs
+++ b/tests/fcm_request_error.rs
@@ -1,4 +1,5 @@
 use serde_json::json;
+use std::fs::File;
 
 use oauth_fcm::{create_shared_token_manager, send_fcm_message_with_url, FcmError, NetworkError};
 
@@ -35,8 +36,9 @@ async fn test_fcm_request_error() {
         )
         .create();
 
-    let shared_token_manager = create_shared_token_manager("tests/mock_credentials.json")
-        .expect("Failed to create SharedTokenManager");
+    let shared_token_manager =
+        create_shared_token_manager(File::open("tests/mock_credentials.json").unwrap())
+            .expect("Failed to create SharedTokenManager");
     // Force refresh with valid url
     shared_token_manager
         .lock()

--- a/tests/fcm_server_error.rs
+++ b/tests/fcm_server_error.rs
@@ -1,4 +1,5 @@
 use serde_json::json;
+use std::fs::File;
 
 use oauth_fcm::{create_shared_token_manager, send_fcm_message_with_url, FcmError, NetworkError};
 
@@ -41,8 +42,9 @@ async fn test_fcm_server_error() {
         .with_body("Internal Server Error")
         .create();
 
-    let shared_token_manager = create_shared_token_manager("tests/mock_credentials.json")
-        .expect("Failed to create SharedTokenManager");
+    let shared_token_manager =
+        create_shared_token_manager(File::open("tests/mock_credentials.json").unwrap())
+            .expect("Failed to create SharedTokenManager");
     // Force refresh with valid url
     shared_token_manager
         .lock()

--- a/tests/oauth_error.rs
+++ b/tests/oauth_error.rs
@@ -1,3 +1,5 @@
+use std::fs::File;
+
 use oauth_fcm::create_shared_token_manager;
 
 use crate::test_helpers::FcmBaseTest;
@@ -24,8 +26,9 @@ async fn failing_oauth_token_refresh() {
         .with_status(400)
         .create();
 
-    let shared_token_manager = create_shared_token_manager("tests/mock_credentials.json")
-        .expect("Failed to create SharedTokenManager");
+    let shared_token_manager =
+        create_shared_token_manager(File::open("tests/mock_credentials.json").unwrap())
+            .expect("Failed to create SharedTokenManager");
 
     let res = {
         let mut guard = shared_token_manager.lock().await;

--- a/tests/valid_fcm_tests.rs
+++ b/tests/valid_fcm_tests.rs
@@ -1,4 +1,8 @@
 use serde_json::json;
+use std::{
+    fs::{self, File},
+    sync::Once,
+};
 
 use oauth_fcm::{create_shared_token_manager, send_fcm_message_with_url};
 
@@ -6,10 +10,12 @@ use crate::test_helpers::{FcmBaseTest, TestData};
 
 mod test_helpers;
 
+static TRACING: Once = Once::new();
+
 #[tokio::test]
 async fn successful_fcm_test() {
     // Output logs to the console
-    tracing_subscriber::fmt::init();
+    TRACING.call_once(tracing_subscriber::fmt::init);
 
     let mut server = mockito::Server::new_async().await;
 
@@ -40,8 +46,83 @@ async fn successful_fcm_test() {
         .with_status(200)
         .create();
 
-    let shared_token_manager = create_shared_token_manager("tests/mock_credentials.json")
-        .expect("Failed to create SharedTokenManager");
+    let shared_token_manager =
+        create_shared_token_manager(File::open("tests/mock_credentials.json").unwrap())
+            .expect("Failed to create SharedTokenManager");
+
+    {
+        let mut guard = shared_token_manager.lock().await;
+
+        assert!(guard.is_token_expired());
+
+        // Get a valid first token from the mock instead of the real server
+        guard
+            .refresh_token_with_url(&base.mock_auth_url())
+            .await
+            .expect("Failed to refresh token");
+
+        assert!(!guard.is_token_expired());
+        assert!(guard.get_token().await.is_ok());
+        assert!(!guard.get_token().await.unwrap().is_empty());
+    }
+
+    let data = TestData {
+        title: "Test title".to_string(),
+        description: "Test description".to_string(),
+    };
+
+    let result = send_fcm_message_with_url(
+        &base.device_token,
+        None,
+        Some(data),
+        &shared_token_manager,
+        &base.mock_fcm_url(),
+    )
+    .await;
+
+    assert!(result.is_ok());
+
+    mock_auth.assert_async().await;
+    mock_fcm.assert_async().await;
+}
+
+#[tokio::test]
+async fn successful_fcm_test_from_string() {
+    // Output logs to the console
+    TRACING.call_once(tracing_subscriber::fmt::init);
+
+    let mut server = mockito::Server::new_async().await;
+
+    let project_id = "mock_project_id";
+    let base = FcmBaseTest::new(
+        server.url(),
+        "/token".to_string(),
+        server.url(),
+        format!("/v1/projects/{}/messages:send", project_id),
+    );
+
+    let mock_auth = server
+        .mock("POST", base.oauth_path.as_str())
+        .with_status(200)
+        .with_body(
+            json!({
+                "access_token": base.access_token,
+                "scope": "https://www.googleapis.com/auth/prediction",
+                "token_type": "Bearer",
+                "expires_in": 3600,
+            })
+            .to_string(),
+        )
+        .create();
+
+    let mock_fcm = server
+        .mock("POST", base.fcm_path.as_str())
+        .with_status(200)
+        .create();
+
+    let creds = fs::read_to_string("tests/mock_credentials.json").unwrap();
+    let shared_token_manager =
+        create_shared_token_manager(creds.as_bytes()).expect("Failed to create SharedTokenManager");
 
     {
         let mut guard = shared_token_manager.lock().await;


### PR DESCRIPTION
Currently, the credentials are expected to be passed as a path to a file on disk, but as type &str. These changes update the interface to accept anything that impl Read, which means you can pass a file handle, &[u8], buffers, etc.

This constitutes a breaking change in the interface; the burden is put on the caller to open the file, read the file, get the credentials from the environment, etc. However, the advantage is that the interface is more flexible.

I also updated all the existing tests to succeed, and added a test verifying that it also succeeds when passing the credentials as a byte slice.

If the breaking change is a problem, we could also leave the impl Read interface on the TokenManager itself, but provide an additional top-level function called something like
create_shared_token_manager_from_slice, or ..._from_reader, etc. I personally prefer the cleaner single flexible entrypoint, but it's not my project!